### PR TITLE
Support resuming broken downloads by only getting missing

### DIFF
--- a/src/skippy_hlsdemux.c
+++ b/src/skippy_hlsdemux.c
@@ -1090,7 +1090,7 @@ skippy_hls_demux_stream_loop (SkippyHLSDemux * demux)
     }
     break;
   case SKIPPY_URI_DOWNLOADER_COMPLETED:
-    GST_DEBUG ("Fragment download completed");
+    GST_DEBUG ("Fragment download completed successfully");
     // Post stats message
     skippy_hls_demux_post_stat_msg (demux, STAT_TIME_TO_DOWNLOAD_FRAGMENT,
       fragment->download_stop_time - fragment->download_start_time, fragment->size);

--- a/src/skippy_uridownloader.c
+++ b/src/skippy_uridownloader.c
@@ -338,6 +338,11 @@ skippy_uri_downloader_handle_bytes_received (SkippyUriDownloader* downloader,
   GstStructure* s;
   float percentage = 100.0f * bytes_loaded / bytes_total;
 
+  // Be silent if we are not linked
+  if (!gst_pad_is_linked (downloader->priv->srcpad)) {
+    return;
+  }
+
   GST_TRACE ("Loaded %ld bytes of %ld -> %f percent of media interval %f to %f seconds",
     (long int) bytes_loaded,
     (long int) bytes_total,


### PR DESCRIPTION
Enables support for cases where the connection breaks and a download only is performed half-way.

In this case our retry will only fetch the missing data.

This is implemented in the URI downloader in a transparent way, and also works for the unlinked mode of the downloader.