### PR TITLE
Downloader 'continue' fix + event handling + potential minor issues + several cosmetic things + naming

### DIFF
--- a/include/skippyHLS/skippy_hlsdemux.h
+++ b/include/skippyHLS/skippy_hlsdemux.h
@@ -59,11 +59,12 @@ struct _SkippyHLSDemux
   GstBin parent;
 
   /* Pads */
+  // External
   GstPad *sinkpad;
   GstPad *srcpad;
+  // Internal
   GstPad *queue_sinkpad;
-  
-  GstPad * _sink_pad;
+  GstPad * queue_proxy_pad;
 
   /* Member objects */
   gboolean need_segment, need_stream_start;

--- a/include/skippyHLS/skippy_hlsdemux.h
+++ b/include/skippyHLS/skippy_hlsdemux.h
@@ -79,6 +79,7 @@ struct _SkippyHLSDemux
   /* Streaming task */
   GstTask *stream_task;
   GRecMutex stream_lock;
+  GCond wait_cond;
 
   /* Internal state */
   GstClockTime position;
@@ -86,6 +87,7 @@ struct _SkippyHLSDemux
   GstClockTime download_ahead;
   gint download_failed_count;
   gboolean continuing;
+  gboolean disposing;
 };
 
 struct _SkippyHLSDemuxClass

--- a/include/skippyHLS/skippy_hlsdemux.h
+++ b/include/skippyHLS/skippy_hlsdemux.h
@@ -82,12 +82,12 @@ struct _SkippyHLSDemux
   GCond wait_cond;
 
   /* Internal state */
+  GstClockTime download_ahead;
   GstClockTime position;
   GstClockTime position_downloaded;
-  GstClockTime download_ahead;
   gint download_failed_count;
   gboolean continuing;
-  gboolean disposing;
+  gboolean end_of_playlist_reached;
 };
 
 struct _SkippyHLSDemuxClass

--- a/include/skippyHLS/skippy_uridownloader.h
+++ b/include/skippyHLS/skippy_uridownloader.h
@@ -75,8 +75,8 @@ SkippyUriDownloaderFetchReturn skippy_uri_downloader_fetch_fragment (SkippyUriDo
 	const gchar * referer, gboolean compress, gboolean refresh, gboolean allow_cache, GError ** err);
 GstBuffer* skippy_uri_downloader_get_buffer (SkippyUriDownloader *downloader);
 
-void skippy_uri_downloader_cancel (SkippyUriDownloader * downloader);
-
 void skippy_uri_downloader_interrupt (SkippyUriDownloader * downloader);
+
+void skippy_uri_downloader_continue (SkippyUriDownloader * downloader);
 
 G_END_DECLS

--- a/src/skippy_hlsdemux.c
+++ b/src/skippy_hlsdemux.c
@@ -427,7 +427,7 @@ skippy_hls_demux_set_context (GstElement *element, GstContext *context)
 {
   SkippyHLSDemux *demux = SKIPPY_HLS_DEMUX (element);
 
-  GstStructure* context_structure = gst_context_get_structure (context);
+  const GstStructure* context_structure = gst_context_get_structure (context);
 
   GstClockTime buffer_ahead = 0;
   if (gst_structure_get_uint64 (context_structure, SKIPPY_HLS_DOWNLOAD_AHEAD, &buffer_ahead)) {
@@ -1003,6 +1003,7 @@ skippy_hls_demux_proxy_pad_event (GstPad *pad, GstObject *parent, GstEvent *even
     gst_event_parse_caps (event, &caps);
     demux->caps = gst_caps_copy (caps);
     GST_OBJECT_UNLOCK (demux);
+  default:
     break;
   }
 


### PR DESCRIPTION
@pokey909 necessary changes i was talking of, but they're mostly beautifying or minor potential bugs but not solving the issue on the config-passing branch.

To sum up what this is:

- Set downloader continue (uncancel) condition to fix potential hickup (as discussed)
- Start task before getting playlist and wait (SKIP-324)
- Various cosmetic stuff and potential issues