### PR TITLE
In some cases instance of GError is not initialized even when fetch_fr…

### DIFF
--- a/src/skippy_hlsdemux.c
+++ b/src/skippy_hlsdemux.c
@@ -1233,7 +1233,15 @@ skippy_hls_demux_stream_loop (SkippyHLSDemux * demux)
     break;
   case SKIPPY_URI_DOWNLOADER_FAILED:
     // When failed
-    g_return_if_fail (err);
+    //TODO: remove this check once we make sure Error instance is initialized in all cases when download fails
+    if (!err) {
+      g_warning ("Error not set but download failed!");
+      if (fragment) {
+        g_object_unref (fragment);
+      }
+      g_free (referrer_uri);
+      return;
+    }
     GST_INFO ("Fragment fetch error: %s", err->message);
     // Actual download failure
     GST_OBJECT_LOCK (demux);

--- a/src/skippy_hlsdemux.c
+++ b/src/skippy_hlsdemux.c
@@ -1233,6 +1233,7 @@ skippy_hls_demux_stream_loop (SkippyHLSDemux * demux)
     break;
   case SKIPPY_URI_DOWNLOADER_FAILED:
     // When failed
+    g_return_if_fail (err);
     GST_INFO ("Fragment fetch error: %s", err->message);
     // Actual download failure
     GST_OBJECT_LOCK (demux);


### PR DESCRIPTION
…agment function returns DOWNLOAD_FAILED. In order to prevent crashes in these cases adding check for error before using it. This is just prevention - we should always make sure that error exists when DOWNLOADER_FAILD code is returned (TODO).