### PR TITLE
SKIP-347 - Playlist downloads should not be resumed in case of an error.

### DIFF
--- a/include/skippyHLS/skippy_m3u8.h
+++ b/include/skippyHLS/skippy_m3u8.h
@@ -46,7 +46,7 @@ gboolean skippy_m3u8_client_seek_to (SkippyM3U8Client * client, GstClockTime tar
 gchar* skippy_m3u8_client_get_uri(SkippyM3U8Client * client);
 
 // Update/set/identify variant (sub-) playlist by URIs advertised in master playlist
-gboolean skippy_m3u8_client_load_playlist (SkippyM3U8Client * client, const gchar *uri, GstBuffer* playlist_buffer, GError** error);
+void skippy_m3u8_client_load_playlist (SkippyM3U8Client * client, const gchar *uri, GstBuffer* playlist_buffer, GError** error);
 
 gchar *skippy_m3u8_client_get_playlist_for_bitrate (SkippyM3U8Client * client, guint bitrate);
 gchar *skippy_m3u8_client_get_current_playlist (SkippyM3U8Client * client);

--- a/include/skippyHLS/skippy_m3u8.h
+++ b/include/skippyHLS/skippy_m3u8.h
@@ -46,7 +46,7 @@ gboolean skippy_m3u8_client_seek_to (SkippyM3U8Client * client, GstClockTime tar
 gchar* skippy_m3u8_client_get_uri(SkippyM3U8Client * client);
 
 // Update/set/identify variant (sub-) playlist by URIs advertised in master playlist
-gboolean skippy_m3u8_client_load_playlist (SkippyM3U8Client * client, const gchar *uri, GstBuffer* playlist_buffer);
+gboolean skippy_m3u8_client_load_playlist (SkippyM3U8Client * client, const gchar *uri, GstBuffer* playlist_buffer, GError** error);
 
 gchar *skippy_m3u8_client_get_playlist_for_bitrate (SkippyM3U8Client * client, guint bitrate);
 gchar *skippy_m3u8_client_get_current_playlist (SkippyM3U8Client * client);

--- a/include/skippyHLS/skippy_m3u8_parser.hpp
+++ b/include/skippyHLS/skippy_m3u8_parser.hpp
@@ -27,7 +27,7 @@ typedef std::vector<SkippyM3UItem> SkippyM3UPlaylistItems;
 struct SkippyM3UPlaylist
 {
   SkippyM3UPlaylist(std::string uri)
-  :uri(uri)
+  : version(0), programId(0), sequenceNo(0), bandwidthKbps(0), targetDuration(0), totalDuration(0), uri(uri), isComplete(false)
   {}
 
   uint64_t version;
@@ -40,6 +40,7 @@ struct SkippyM3UPlaylist
   std::string resolution;
   std::string uri;
   std::string type;
+  bool isComplete;
 
   SkippyM3UPlaylistItems items;
 };
@@ -106,7 +107,7 @@ private:
   double length;
   uint64_t index;
   uint64_t position;
-
+  
   // URI state vars
   std::string url;
 };

--- a/include/skippyHLS/skippy_uridownloader.h
+++ b/include/skippyHLS/skippy_uridownloader.h
@@ -50,12 +50,6 @@ typedef enum {
 	SKIPPY_URI_DOWNLOADER_COMPLETED,
 } SkippyUriDownloaderFetchReturn;
 
-typedef enum {
-  SKIPPY_URI_DOWNLOADER_INTERRUPTED_DOWNLOADS_POLICY_NOT_SET = 0,
-  SKIPPY_URI_DOWNLOADER_INTERRUPTED_DOWNLOADS_POLICY_DISCARD,
-  SKIPPY_URI_DOWNLOADER_INTERRUPTED_DOWNLOADS_POLICY_RESUME
-} SkippyUriDownloaderInterruptedDownloadPolicy;
-
 struct _SkippyUriDownloader
 {
   GstBin parent;
@@ -74,7 +68,7 @@ struct _SkippyUriDownloaderClass
 GType skippy_uri_downloader_get_type (void);
 
 // URI can be NULL (then source will be created on demand with first fetch)
-SkippyUriDownloader * skippy_uri_downloader_new (SkippyUriDownloaderInterruptedDownloadPolicy policy);
+SkippyUriDownloader * skippy_uri_downloader_new (gboolean resume_interrupted_downloads);
 
 void skippy_uri_downloader_prepare (SkippyUriDownloader * downloader, gchar* uri);
 SkippyUriDownloaderFetchReturn skippy_uri_downloader_fetch_fragment (SkippyUriDownloader * downloader, SkippyFragment* fragment,

--- a/include/skippyHLS/skippy_uridownloader.h
+++ b/include/skippyHLS/skippy_uridownloader.h
@@ -50,6 +50,12 @@ typedef enum {
 	SKIPPY_URI_DOWNLOADER_COMPLETED,
 } SkippyUriDownloaderFetchReturn;
 
+typedef enum {
+  SKIPPY_URI_DOWNLOADER_INTERRUPTED_DOWNLOADS_POLICY_NOT_SET = 0,
+  SKIPPY_URI_DOWNLOADER_INTERRUPTED_DOWNLOADS_POLICY_DISCARD,
+  SKIPPY_URI_DOWNLOADER_INTERRUPTED_DOWNLOADS_POLICY_RESUME
+} SkippyUriDownloaderInterruptedDownloadPolicy;
+
 struct _SkippyUriDownloader
 {
   GstBin parent;
@@ -68,7 +74,7 @@ struct _SkippyUriDownloaderClass
 GType skippy_uri_downloader_get_type (void);
 
 // URI can be NULL (then source will be created on demand with first fetch)
-SkippyUriDownloader * skippy_uri_downloader_new ();
+SkippyUriDownloader * skippy_uri_downloader_new (SkippyUriDownloaderInterruptedDownloadPolicy policy);
 
 void skippy_uri_downloader_prepare (SkippyUriDownloader * downloader, gchar* uri);
 SkippyUriDownloaderFetchReturn skippy_uri_downloader_fetch_fragment (SkippyUriDownloader * downloader, SkippyFragment* fragment,

--- a/src/skippy_hls_priv.h
+++ b/src/skippy_hls_priv.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include <glib.h>
+
+#define SKIPPY_HLS_ERROR skippy_hls_error_quark()
+G_GNUC_INTERNAL GQuark skippy_hls_error_quark(void);
+
+typedef enum {
+  SKIPPY_HLS_ERROR_PLAYLIST_INVALID_UTF_CONTENT,
+  SKIPPY_HLS_ERROR_PLAYLIST_INCOMPLETE,
+} SkippyHlsError;

--- a/src/skippy_hlsdemux.c
+++ b/src/skippy_hlsdemux.c
@@ -1076,17 +1076,17 @@ skippy_hls_demux_refresh_playlist (SkippyHLSDemux * demux)
     // Load M3U8 buffer into parser
     buf = skippy_uri_downloader_get_buffer (demux->playlist_downloader);
     
-    skippy_m3u8_client_load_playlist (demux->client, current_playlist, buf, &load_err);
+    g_clear_error (&err);
+    skippy_m3u8_client_load_playlist (demux->client, current_playlist, buf, &err);
     
-    if (load_err) {
-      if (g_error_matches(load_err, SKIPPY_HLS_ERROR, SKIPPY_HLS_ERROR_PLAYLIST_INCOMPLETE)) {
+    if (err) {
+      if (g_error_matches(err, SKIPPY_HLS_ERROR, SKIPPY_HLS_ERROR_PLAYLIST_INCOMPLETE)) {
         REPORT_NON_FATAL_ERROR (demux, ("While refreshing playlist: Incomplete M3U8 data."), ("%s", skippy_m3u8_client_get_current_raw_data (demux->client)));
       }
       else {
         REPORT_NON_FATAL_ERROR (demux, ("While refreshing playlist: Invalid M3U8 data (buffer: %p)", buf), (NULL));
       }
       ret = FALSE;
-      g_clear_error (&load_err);
       break;
     }
     
@@ -1097,7 +1097,6 @@ skippy_hls_demux_refresh_playlist (SkippyHLSDemux * demux)
   case SKIPPY_URI_DOWNLOADER_VOID:
     if (err) {
       GST_ERROR ("Error updating playlist: %s", err->message);
-      g_clear_error (&err);
     }
     ret = FALSE;
     break;
@@ -1106,7 +1105,8 @@ skippy_hls_demux_refresh_playlist (SkippyHLSDemux * demux)
   if (buf) {
     gst_buffer_unref (buf);
   }
-
+  
+  g_clear_error (&err);
   g_free (main_playlist_uri);
   g_free (current_playlist);
   return ret;

--- a/src/skippy_hlsdemux.c
+++ b/src/skippy_hlsdemux.c
@@ -175,8 +175,8 @@ skippy_hls_demux_init (SkippyHLSDemux * demux)
   // Internal elements
   demux->download_queue = gst_element_factory_make ("queue2", "skippyhlsdemux-download-queue");
   demux->queue_sinkpad = gst_element_get_static_pad (demux->download_queue, "sink");
-  demux->downloader = skippy_uri_downloader_new (SKIPPY_URI_DOWNLOADER_INTERRUPTED_DOWNLOADS_POLICY_RESUME);
-  demux->playlist_downloader = skippy_uri_downloader_new (SKIPPY_URI_DOWNLOADER_INTERRUPTED_DOWNLOADS_POLICY_DISCARD);
+  demux->downloader = skippy_uri_downloader_new (TRUE);
+  demux->playlist_downloader = skippy_uri_downloader_new (FALSE);
 
   demux->queue_proxy_pad = gst_pad_new ("skippyhlsdemux-queue-proxy-pad", GST_PAD_SINK);
   gst_pad_set_element_private (demux->queue_proxy_pad, demux);

--- a/src/skippy_hlsdemux.c
+++ b/src/skippy_hlsdemux.c
@@ -629,7 +629,9 @@ skippy_hls_demux_handle_first_playlist (SkippyHLSDemux* demux)
   GST_OBJECT_LOCK (demux);
   
   if (G_UNLIKELY(demux->playlist == NULL)) {
+    GST_OBJECT_UNLOCK (demux);
     REPORT_FATAL_ERROR (demux, STREAM, DECODE, ("First playlist: Invalid M3U8 data (buffer=%p)", demux->playlist), (NULL));
+    goto error;
   }
   
   skippy_m3u8_client_load_playlist (demux->client, uri, demux->playlist, &error);

--- a/src/skippy_hlsdemux.c
+++ b/src/skippy_hlsdemux.c
@@ -1069,7 +1069,7 @@ skippy_hls_demux_refresh_playlist (SkippyHLSDemux * demux)
     
     if (load_err) {
       if (g_error_matches(load_err, SKIPPY_HLS_ERROR, SKIPPY_HLS_ERROR_PLAYLIST_INCOMPLETE)) {
-        GST_ELEMENT_ERROR (demux, RESOURCE, READ,  ("While refreshing playlist: Incomplete M3U8 data."), (("%s", skippy_m3u8_client_get_current_raw_data (demux->client))));
+        GST_ELEMENT_ERROR (demux, RESOURCE, READ,  ("While refreshing playlist: Incomplete M3U8 data."), ("%s", skippy_m3u8_client_get_current_raw_data (demux->client)));
       }
       else {
         GST_ELEMENT_ERROR (demux, STREAM, DECODE, ("While refreshing playlist: Invalid M3U8 data (buffer: %p)", buf), (NULL));

--- a/src/skippy_hlsdemux.c
+++ b/src/skippy_hlsdemux.c
@@ -175,8 +175,8 @@ skippy_hls_demux_init (SkippyHLSDemux * demux)
   // Internal elements
   demux->download_queue = gst_element_factory_make ("queue2", "skippyhlsdemux-download-queue");
   demux->queue_sinkpad = gst_element_get_static_pad (demux->download_queue, "sink");
-  demux->downloader = skippy_uri_downloader_new ();
-  demux->playlist_downloader = skippy_uri_downloader_new ();
+  demux->downloader = skippy_uri_downloader_new (SKIPPY_URI_DOWNLOADER_INTERRUPTED_DOWNLOADS_POLICY_RESUME);
+  demux->playlist_downloader = skippy_uri_downloader_new (SKIPPY_URI_DOWNLOADER_INTERRUPTED_DOWNLOADS_POLICY_DISCARD);
 
   demux->queue_proxy_pad = gst_pad_new ("skippyhlsdemux-queue-proxy-pad", GST_PAD_SINK);
   gst_pad_set_element_private (demux->queue_proxy_pad, demux);

--- a/src/skippy_hlsdemux.c
+++ b/src/skippy_hlsdemux.c
@@ -367,7 +367,7 @@ skippy_hls_demux_restart (SkippyHLSDemux * demux, gboolean force)
 //
 // MT-safe
 static void
-    skippy_hls_demux_stop (SkippyHLSDemux *demux)
+skippy_hls_demux_stop (SkippyHLSDemux *demux)
 {
   // Let's join the streaming thread
   GST_DEBUG ("Stopping task ...");
@@ -1310,7 +1310,6 @@ skippy_hls_demux_stream_loop (SkippyHLSDemux * demux)
         ("M3U8 data seems to be corrupt as it results in permanent 403s. Broken URL: %s, Failure count: %d, Error: %s",
           fragment->uri, (int) demux->download_forbidden_count, err->message),
         ("\n\n%s\n\n", skippy_m3u8_client_get_current_raw_data (demux->client)));
-        gst_task_pause (demux->stream_task); // avoid retrying immediatly
       }
       skippy_hls_demux_refresh_playlist (demux);
       playlist_refresh = TRUE;

--- a/src/skippy_hlsdemux.c
+++ b/src/skippy_hlsdemux.c
@@ -1044,7 +1044,6 @@ skippy_hls_demux_refresh_playlist (SkippyHLSDemux * demux)
   SkippyFragment *download;
   GstBuffer *buf = NULL;
   GError* err = NULL;
-  GError* load_err = NULL;
   SkippyUriDownloaderFetchReturn fetch_ret;
   gboolean ret = FALSE;
   gchar *current_playlist = skippy_m3u8_client_get_current_playlist (demux->client);

--- a/src/skippy_m3u8.cpp
+++ b/src/skippy_m3u8.cpp
@@ -96,7 +96,7 @@ gboolean skippy_m3u8_client_load_playlist (SkippyM3U8Client * client, const gcha
   SkippyM3UParser p;
   gchar* playlist = buf_to_utf8_playlist (playlist_buffer);
   if (!playlist) {
-    *error = g_error_new (SKIPPY_HLS_ERROR, SKIPPY_HLS_ERROR_PLAYLIST_INVALID_UTF_CONTENT, "", NULL);
+    *error = g_error_new (SKIPPY_HLS_ERROR, SKIPPY_HLS_ERROR_PLAYLIST_INVALID_UTF_CONTENT, "%s", "");
     return FALSE;
   }
   {
@@ -109,7 +109,7 @@ gboolean skippy_m3u8_client_load_playlist (SkippyM3U8Client * client, const gcha
     client->priv->playlist_raw = playlist;
     
     if (!client->priv->playlist.isComplete) {
-      *error = g_error_new (SKIPPY_HLS_ERROR, SKIPPY_HLS_ERROR_PLAYLIST_INCOMPLETE, "", (NULL));
+      *error = g_error_new (SKIPPY_HLS_ERROR, SKIPPY_HLS_ERROR_PLAYLIST_INCOMPLETE, "%s", "");
       return FALSE;
     }
   }

--- a/src/skippy_m3u8.cpp
+++ b/src/skippy_m3u8.cpp
@@ -102,16 +102,17 @@ gboolean skippy_m3u8_client_load_playlist (SkippyM3U8Client * client, const gcha
   {
     lock_guard<recursive_mutex> lock(client->priv->mutex);
     string loaded_playlist_uri = (uri != NULL) ? uri : client->priv->playlist.uri;
-    client->priv->playlist = p.parse(loaded_playlist_uri, playlist);
+    SkippyM3UPlaylist loaded_playlist = p.parse(loaded_playlist_uri, playlist);
     
     //update raw playlist
     g_free (client->priv->playlist_raw);
     client->priv->playlist_raw = playlist;
     
-    if (!client->priv->playlist.isComplete) {
+    if (!loaded_playlist.isComplete) {
       *error = g_error_new (SKIPPY_HLS_ERROR, SKIPPY_HLS_ERROR_PLAYLIST_INCOMPLETE, "%s", "");
       return FALSE;
     }
+    client->priv->playlist = loaded_playlist;
   }
   return TRUE;
 }

--- a/src/skippy_m3u8_parser.cpp
+++ b/src/skippy_m3u8_parser.cpp
@@ -71,7 +71,6 @@ SkippyM3UParser::SkippyM3UParser()
 ,length(0)
 ,index(0)
 ,position(0)
-
 {}
 
 SkippyM3UPlaylist SkippyM3UParser::parse(string uri, const string& playlist)
@@ -195,8 +194,8 @@ void SkippyM3UParser::evalSubstate() {
 
     LOG("Sub-State to: RESET (end of list)");
 
-  subState = SUBSTATE_END;
-
+    subState = SUBSTATE_END;
+    
   } else {
 
     LOG("Sub-State to: RESET (unknown token): %s", token.c_str());
@@ -315,6 +314,7 @@ void SkippyM3UParser::update(SkippyM3UPlaylist& playlist) {
       playlist.targetDuration = targetDuration * UNIT_SECONDS;
       playlist.totalDuration = position;
       playlist.type = playlistType;
+      playlist.isComplete = true;
       break;
     default:
       break;

--- a/src/skippy_uridownloader.c
+++ b/src/skippy_uridownloader.c
@@ -251,21 +251,21 @@ skippy_uri_downloader_reset (SkippyUriDownloader * downloader, SkippyFragment* n
   // NOTE: we do the string comparison only after the bytes count is off as its more expensive
   // If we are seeking in some way then we wont consider resuming at all.
 #if DOWNLOAD_RESUMING_ENABLED
-  if (downloader->priv->interrupted_downloads_policy == SKIPPY_URI_DOWNLOADER_INTERRUPTED_DOWNLOADS_POLICY_RESUME) {
-    if (G_UNLIKELY(
-      // Did we not complete the previous download?
-       downloader->priv->bytes_loaded != downloader->priv->bytes_total
-       // reset might not be called to prepare a fetch and/or there might be no previous download
-       && next_fragment && downloader->priv->fragment && !downloader->priv->fragment->cancelled
-       // Is it the same URI?
-       && compare_uri_resource_path (next_fragment->uri, downloader->priv->fragment->uri))) {
-      // If the previous download was not completed and we are currently retrying the same
-      // we are not resetting the fields and will later perform a range request to get only
-      // the missing stuff.
-      GST_DEBUG ("Previous download interruption detected");
-      downloader->priv->previous_was_interrupted = TRUE;
-    }
-  } else
+  if (G_LIKELY(downloader->priv->interrupted_downloads_policy == SKIPPY_URI_DOWNLOADER_INTERRUPTED_DOWNLOADS_POLICY_RESUME)
+    && G_UNLIKELY(
+    // Did we not complete the previous download?
+    downloader->priv->bytes_loaded != downloader->priv->bytes_total
+    // reset might not be called to prepare a fetch and/or there might be no previous download
+    && next_fragment && downloader->priv->fragment && !downloader->priv->fragment->cancelled
+    // Is it the same URI?
+    && compare_uri_resource_path (next_fragment->uri, downloader->priv->fragment->uri))) {
+    // If the previous download was not completed and we are currently retrying the same
+    // we are not resetting the fields and will later perform a range request to get only
+    // the missing stuff.
+    GST_DEBUG ("Previous download interruption detected");
+    downloader->priv->previous_was_interrupted = TRUE;
+  }
+  else
 #endif
   {
     // If above condition does not hold: Fresh new download state


### PR DESCRIPTION
- resume download policy is now property of skippy_uri_downloader class. It could be set only when constructing object to avoid issues with runtime setting.
- playlist downloader will discard interrupted downloads.