### PR TITLE
Download failed return code should always imply having error set

### DIFF
--- a/src/skippy_hlsdemux.c
+++ b/src/skippy_hlsdemux.c
@@ -1225,7 +1225,7 @@ skippy_hls_demux_stream_loop (SkippyHLSDemux * demux)
   switch (fetch_ret) {
   // This case means the download did not do anything
   case SKIPPY_URI_DOWNLOADER_VOID:
-    // Error & fragment should be NULL
+    // Error should be NULL
     skippy_hls_handle_end_of_playlist (demux);
     break;
   case SKIPPY_URI_DOWNLOADER_CANCELLED:
@@ -1233,15 +1233,6 @@ skippy_hls_demux_stream_loop (SkippyHLSDemux * demux)
     break;
   case SKIPPY_URI_DOWNLOADER_FAILED:
     // When failed
-    //TODO: remove this check once we make sure Error instance is initialized in all cases when download fails
-    if (!err) {
-      g_warning ("Error not set but download failed!");
-      if (fragment) {
-        g_object_unref (fragment);
-      }
-      g_free (referrer_uri);
-      return;
-    }
     GST_INFO ("Fragment fetch error: %s", err->message);
     // Actual download failure
     GST_OBJECT_LOCK (demux);


### PR DESCRIPTION
@milos-pesic-sc @pokey909 on a quick one, couldn't resist. I think this is safe and nicer :) what do you think?

downloader failed code should imply err is set - this commit makes sure it is. VOID code will imply that the attempt was not made because of internal failures (not actual HTTP related). err will not be set in this case but assertions/warnings will be hit internally that would make test code fail in case these points are reached. HLS stream loop will handle as end of playlist if reaching void code. refresh playlist routine handles all cases gracefully.
