### PR TITLE
instead of using redirect URI as a playlist URI, use the original URI…

### DIFF
--- a/src/skippy_hlsdemux.c
+++ b/src/skippy_hlsdemux.c
@@ -484,22 +484,13 @@ skippy_hls_demux_query_location (SkippyHLSDemux * demux)
 {
   GstQuery* query = gst_query_new_uri ();
   gboolean ret = gst_pad_peer_query (demux->sinkpad, query);
-  gboolean permanent;
-  gchar *uri;
+  gchar *uri = NULL;
 
   if (ret) {
-    gst_query_parse_uri_redirection (query, &uri);
-    gst_query_parse_uri_redirection_permanent (query, &permanent);
-
-    /* Only use the redirect target for permanent redirects */
-    if (!permanent || uri == NULL) {
-      g_free (uri);
-      gst_query_parse_uri (query, &uri);
-    }
-    return uri;
+    gst_query_parse_uri (query, &uri);
   }
   gst_query_unref (query);
-  return NULL;
+  return uri;
 }
 
 // Queries current playback position from downstream element


### PR DESCRIPTION
… which will be used as a referrer (this is important for HTTP cache as it uses original URI as well)

@milos-pesic-sc @pokey909 this is fixing our current network test failures, as we are shooting the cache in the foot by not using the original URI as a referrer (this only showed up since the redirect URI actually *is* the redirect with skippy httpsrc :D )